### PR TITLE
Convert async --> non_blocking for Python 3.7

### DIFF
--- a/examples/gpubox.py
+++ b/examples/gpubox.py
@@ -37,7 +37,7 @@ def main():
               '/efs/notebooks/gpubox_sample.ipynb',
               dont_overwrite=True)
   task.run('cd /efs/notebooks')
-  task.run('jupyter notebook', async=True)
+  task.run('jupyter notebook', non_blocking=True)
   print(f'Jupyter notebook will be at http://{task.public_ip}:8888')
 
 

--- a/examples/gpubox_jupyter_notebook_config.py
+++ b/examples/gpubox_jupyter_notebook_config.py
@@ -6365,7 +6365,7 @@
 
 
 
-
+c = c  # noqa: The global c is created by Jupyter
 c.NotebookApp.ip = '*'
 
 

--- a/examples/tf_adder.py
+++ b/examples/tf_adder.py
@@ -71,7 +71,8 @@ def run_launcher():
     job.run('source activate tensorflow_p36')
 
   ip_config = f'--sender-ip={sender.ip} --receiver-ip={receiver.ip}'
-  job.tasks[1].run(f'python tf_adder.py --role=receiver {ip_config}', async=True)
+  job.tasks[1].run(f'python tf_adder.py --role=receiver {ip_config}',
+                   non_blocking=True)
   job.tasks[0].run(f'python tf_adder.py --role=sender {ip_config}')
 
 

--- a/examples/tf_adder_tb.py
+++ b/examples/tf_adder_tb.py
@@ -70,9 +70,9 @@ def run_launcher():
     job.run('source activate tensorflow_p36')
 
   ip_config = f'--sender-ip={sender.ip} --receiver-ip={receiver.ip}'
-  job.tasks[1].run(f'python {this_file} --role=receiver {ip_config}', async=True)
+  job.tasks[1].run(f'python {this_file} --role=receiver {ip_config}', non_blocking=True)
   job.tasks[0].run(f'python {this_file} --role=sender --logdir={job.logdir} {ip_config}')
-  job.tasks[0].run(f'tensorboard --logdir={job.logdir}/..', async=True)
+  job.tasks[0].run(f'tensorboard --logdir={job.logdir}/..', non_blocking=True)
   print(f"Benchmark done, tensorboard at http://{job.tasks[0].public_ip}:6006")
 
 

--- a/ncluster/aws_backend.py
+++ b/ncluster/aws_backend.py
@@ -238,7 +238,7 @@ tmux a
 
   # TODO(y): build a pstree and warn if trying to run something while main tmux bash has a subprocess running
   # this would ensure that commands being sent are not being swallowed
-  def run(self, cmd, async=False, ignore_errors=False,
+  def run(self, cmd, non_blocking=False, ignore_errors=False,
           max_wait_sec=365 * 24 * 3600,
           check_interval=0.5) -> int:
 
@@ -261,7 +261,7 @@ tmux a
 
     tmux_cmd = f"tmux send-keys -t {self._tmux_window} {modified_cmd} Enter"
     self._run_raw(tmux_cmd)
-    if async:
+    if non_blocking:
       return 0
 
     if not self.wait_for_file(status_fn, max_wait_sec=60):

--- a/ncluster/local_backend.py
+++ b/ncluster/local_backend.py
@@ -66,7 +66,7 @@ class Task(backend.Task):
     for line in install_script.split('\n'):
       self.run(line)
 
-  def run(self, cmd, async=False, ignore_errors=False, **kwargs) -> int:
+  def run(self, cmd, non_blocking=False, ignore_errors=False, **kwargs) -> int:
     self.run_counter += 1
     cmd = cmd.strip()
     if not cmd or cmd.startswith('#'):  # ignore empty/commented out lines
@@ -86,7 +86,7 @@ class Task(backend.Task):
 
     tmux_cmd = f'tmux send-keys -t {self.tmux_window} {modified_cmd} Enter'
     self._run_raw(tmux_cmd)
-    if async:
+    if non_blocking:
       return 0
 
     self.wait_for_file(status_fn)


### PR DESCRIPTION
Fixes #8.  __async__ is a reserved word in Python 3.7 so convert all instances of __async__ into instances of __non_blocking__.  Also document that the global variable __c__ is created by Jupyter.